### PR TITLE
Add emergency types seeding button

### DIFF
--- a/app/Http/Controllers/EmergencyTypeController.php
+++ b/app/Http/Controllers/EmergencyTypeController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\EmergencyType;
+use Illuminate\Http\RedirectResponse;
+
+class EmergencyTypeController extends Controller
+{
+    public function seed(): RedirectResponse
+    {
+        $types = [
+            ['code' => '10-0', 'description' => 'Llamado estructural'],
+            ['code' => '10-0-1', 'description' => 'Casa habitación / Local comercial'],
+            ['code' => '10-0-2', 'description' => 'Edificio'],
+            ['code' => '10-0-3', 'description' => 'Fábrica / Local público'],
+            ['code' => '10-0-4', 'description' => 'Población / Alto riesgo'],
+            ['code' => '10-0-5', 'description' => 'Depósito Hazmat o gas / Explosión'],
+            ['code' => '10-0-6', 'description' => 'Subterráneo'],
+            ['code' => '10-1', 'description' => 'Fuego en vehículo'],
+            ['code' => '10-2', 'description' => 'Pastizales / Forestal'],
+            ['code' => '10-3', 'description' => 'Salvamento de personas'],
+            ['code' => '10-4', 'description' => 'Rescate vehicular'],
+            ['code' => '10-5', 'description' => 'Incidente Hazmat'],
+            ['code' => '10-6', 'description' => 'Emanación de gas'],
+            ['code' => '10-7', 'description' => 'Emergencia eléctrica'],
+            ['code' => '10-8', 'description' => 'Llamado no clasificado'],
+            ['code' => '10-9', 'description' => 'Apoyo a otros servicios (no emergencia)'],
+            ['code' => '10-10', 'description' => 'Remoción de escombros o rebrote'],
+            ['code' => '10-11', 'description' => 'Servicio aéreo'],
+            ['code' => '10-12', 'description' => 'Apoyo a otro cuerpo de bomberos'],
+            ['code' => '10-13', 'description' => 'Atentado terrorista'],
+            ['code' => '10-14', 'description' => 'Avión que cayó o impactó estructura'],
+            ['code' => '10-15', 'description' => 'Simulacro'],
+            ['code' => '10-16', 'description' => 'Emergencia en túnel'],
+            ['code' => '10-17', 'description' => 'Emergencia en Metro'],
+        ];
+
+        foreach ($types as $type) {
+            EmergencyType::firstOrCreate(
+                ['code' => $type['code']],
+                ['description' => $type['description']]
+            );
+        }
+
+        return back()->with('success', 'Tipos de emergencia creados.');
+    }
+}

--- a/resources/views/emergencies/create.blade.php
+++ b/resources/views/emergencies/create.blade.php
@@ -4,6 +4,13 @@
 <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow">
     <h1 class="text-2xl font-bold text-gray-800 mb-6">Registrar emergencia</h1>
 
+    <form action="{{ route('emergency-types.seed') }}" method="POST" class="mb-4">
+        @csrf
+        <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-3 py-1 rounded">
+            Crear tipos de emergencia
+        </button>
+    </form>
+
     <form action="{{ route('emergencies.store') }}" method="POST" class="space-y-5">
         @csrf
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\DispatchController;
 use App\Http\Controllers\CompanyController;
 use App\Http\Controllers\VolunteerController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\EmergencyTypeController;
 
 
 
@@ -37,6 +38,7 @@ Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard
 
 //menu
 Route::resource('emergencies', EmergencyController::class);
+Route::post('emergency-types/seed', [EmergencyTypeController::class, 'seed'])->name('emergency-types.seed');
 Route::get('/emergencies/{emergency}', [EmergencyController::class, 'show'])->name('emergencies.show');
 Route::put('/emergencies/{emergency}/finalize', [EmergencyController::class, 'finalize'])->name('emergencies.finalize');
 Route::delete('/emergencies/{emergency}', [EmergencyController::class, 'destroy'])


### PR DESCRIPTION
## Summary
- add EmergencyTypeController with a `seed` action
- register new route for seeding emergency types
- add button on emergency creation page to seed types

## Testing
- `php artisan test` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68463f0598d88330bf43ceaeed3d5eb0