### PR TITLE
Add volunteer mobile signup and service control

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Emergency;
 use App\Models\Unit;
+use App\Models\Volunteer;
 use Illuminate\Support\Facades\DB;
 
 class DashboardController extends Controller
@@ -21,6 +22,8 @@ class DashboardController extends Controller
         $unidadesTotales = Unit::count();
         $unidadesDisponibles = Unit::where('availability', true)->count();
         $unidadesOcupadas = Unit::where('availability', false)->count();
+
+        $voluntariosServicio = Volunteer::where('service_code', '09')->get();
 
         // Gráfico de emergencias por tipo
         $porTipo = Emergency::select('type', DB::raw('count(*) as total'))
@@ -42,6 +45,7 @@ class DashboardController extends Controller
             'unidadesTotales',
             'unidadesDisponibles',
             'unidadesOcupadas',
+            'voluntariosServicio',
             'porTipo',
             'porPrioridad'
         ));

--- a/app/Http/Controllers/VolunteerController.php
+++ b/app/Http/Controllers/VolunteerController.php
@@ -8,6 +8,30 @@ use Illuminate\Http\Request;
 
 class VolunteerController extends Controller
 {
+    public function signup()
+    {
+        $companies = Company::all();
+        return view('volunteers.signup', compact('companies'));
+    }
+
+    public function signupStore(Request $request)
+    {
+        $request->validate([
+            'company_id' => 'required|exists:companies,id',
+            'name' => 'required|string|max:255',
+            'rut' => 'required|string|unique:volunteers,rut',
+            'email' => 'nullable|email',
+            'phone' => 'nullable|string|max:20',
+            'position' => 'nullable|string|max:100',
+        ]);
+
+        $data = $request->only('company_id', 'name', 'rut', 'email', 'phone', 'position');
+        $data['service_code'] = '08';
+
+        $volunteer = Volunteer::create($data);
+
+        return redirect()->route('volunteers.service', $volunteer)->with('success', 'Registrado correctamente');
+    }
     public function create(Request $request)
     {
         $company = Company::findOrFail($request->company);
@@ -36,39 +60,55 @@ class VolunteerController extends Controller
 
         return redirect()->route('companies.volunteers', $request->company_id)->with('success', 'Voluntario registrado con éxito.');
     }
-    public function edit(Volunteer $volunteer)
-{
-    $company = $volunteer->company;
-    return view('volunteers.edit', compact('volunteer', 'company'));
-}
 
-public function update(Request $request, Volunteer $volunteer)
-{
-    $request->validate([
-        'name' => 'required|string|max:255',
-        'rut' => 'required|string|unique:volunteers,rut,' . $volunteer->id,
-        'email' => 'nullable|email',
-        'phone' => 'nullable|string|max:20',
-        'position' => 'nullable|string|max:100',
-        'photo' => 'nullable|image|max:2048',
-    ]);
-
-    $data = $request->only('name', 'rut', 'email', 'phone', 'position');
-
-    if ($request->hasFile('photo')) {
-        $data['photo'] = $request->file('photo')->store('volunteers', 'public');
+    public function service(Volunteer $volunteer)
+    {
+        return view('volunteers.service', compact('volunteer'));
     }
 
-    $volunteer->update($data);
+    public function updateService(Request $request, Volunteer $volunteer)
+    {
+        $request->validate([
+            'service_code' => 'required|in:08,09',
+        ]);
 
-    return redirect()->route('companies.volunteers', $volunteer->company_id)->with('success', 'Voluntario actualizado.');
-}
+        $volunteer->update(['service_code' => $request->service_code]);
 
-public function destroy(Volunteer $volunteer)
-{
-    $companyId = $volunteer->company_id;
-    $volunteer->delete();
+        return back()->with('success', 'Estado actualizado');
+    }
+    public function edit(Volunteer $volunteer)
+    {
+        $company = $volunteer->company;
+        return view('volunteers.edit', compact('volunteer', 'company'));
+    }
 
-    return redirect()->route('companies.volunteers', $companyId)->with('success', 'Voluntario eliminado.');
-}
+    public function update(Request $request, Volunteer $volunteer)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'rut' => 'required|string|unique:volunteers,rut,' . $volunteer->id,
+            'email' => 'nullable|email',
+            'phone' => 'nullable|string|max:20',
+            'position' => 'nullable|string|max:100',
+            'photo' => 'nullable|image|max:2048',
+        ]);
+
+        $data = $request->only('name', 'rut', 'email', 'phone', 'position');
+
+        if ($request->hasFile('photo')) {
+            $data['photo'] = $request->file('photo')->store('volunteers', 'public');
+        }
+
+        $volunteer->update($data);
+
+        return redirect()->route('companies.volunteers', $volunteer->company_id)->with('success', 'Voluntario actualizado.');
+    }
+
+    public function destroy(Volunteer $volunteer)
+    {
+        $companyId = $volunteer->company_id;
+        $volunteer->delete();
+
+        return redirect()->route('companies.volunteers', $companyId)->with('success', 'Voluntario eliminado.');
+    }
 }

--- a/app/Models/Volunteer.php
+++ b/app/Models/Volunteer.php
@@ -5,7 +5,17 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 
 class Volunteer extends Model
-{   protected $fillable = ['name', 'rut', 'email', 'phone', 'photo', 'position', 'company_id'];
+{
+    protected $fillable = [
+        'name',
+        'rut',
+        'email',
+        'phone',
+        'photo',
+        'position',
+        'company_id',
+        'service_code',
+    ];
 
     public function company()
 {

--- a/database/migrations/2025_05_26_235000_add_service_code_to_volunteers_table.php
+++ b/database/migrations/2025_05_26_235000_add_service_code_to_volunteers_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('volunteers', function (Blueprint $table) {
+            $table->string('service_code', 2)->default('08');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('volunteers', function (Blueprint $table) {
+            $table->dropColumn('service_code');
+        });
+    }
+};

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -28,6 +28,20 @@
         </div>
     </div>
 
+    {{-- Voluntarios en servicio --}}
+    <div class="bg-white rounded shadow p-6 mb-6">
+        <h2 class="text-xl font-bold mb-4">Voluntarios en Servicio</h2>
+        @if($voluntariosServicio->isEmpty())
+            <p class="text-gray-500">No hay voluntarios en servicio.</p>
+        @else
+            <ul class="list-disc list-inside">
+                @foreach($voluntariosServicio as $vol)
+                    <li>{{ $vol->name }} – {{ $vol->company->name }}</li>
+                @endforeach
+            </ul>
+        @endif
+    </div>
+
     {{-- Gráfico por tipo --}}
     <div class="bg-white rounded shadow p-6 mb-6">
         <h2 class="text-xl font-bold mb-4">Emergencias por Tipo</h2>

--- a/resources/views/volunteers/service.blade.php
+++ b/resources/views/volunteers/service.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.guest')
+
+@section('content')
+<div class="space-y-6 text-center">
+    <h1 class="text-xl font-bold">Hola {{ $volunteer->name }}</h1>
+    <p class="text-gray-600">Estado actual: <span class="font-semibold">{{ $volunteer->service_code == '09' ? 'En servicio' : 'No disponible' }}</span></p>
+    @if(session('success'))
+        <div class="bg-green-100 text-green-700 px-4 py-2 rounded">{{ session('success') }}</div>
+    @endif
+    <form action="{{ route('volunteers.service.update', $volunteer) }}" method="POST" class="space-y-4">
+        @csrf
+        <button type="submit" name="service_code" value="09" class="w-full bg-green-600 text-white py-2 rounded">Quedar en servicio (09)</button>
+        <button type="submit" name="service_code" value="08" class="w-full bg-red-600 text-white py-2 rounded">No disponible (08)</button>
+    </form>
+</div>
+@endsection

--- a/resources/views/volunteers/signup.blade.php
+++ b/resources/views/volunteers/signup.blade.php
@@ -1,0 +1,40 @@
+@extends('layouts.guest')
+
+@section('content')
+<div class="space-y-6">
+    <h1 class="text-xl font-bold text-center">Registro de Voluntario</h1>
+    <form action="{{ route('volunteers.signup.store') }}" method="POST" class="space-y-4">
+        @csrf
+        <div>
+            <label class="block mb-1">Compañía</label>
+            <select name="company_id" class="w-full border rounded px-3 py-2" required>
+                <option value="" disabled selected>Seleccione...</option>
+                @foreach($companies as $c)
+                    <option value="{{ $c->id }}">{{ $c->name }}</option>
+                @endforeach
+            </select>
+        </div>
+        <div>
+            <label class="block mb-1">Nombre</label>
+            <input type="text" name="name" class="w-full border rounded px-3 py-2" required>
+        </div>
+        <div>
+            <label class="block mb-1">RUT</label>
+            <input type="text" name="rut" class="w-full border rounded px-3 py-2" required>
+        </div>
+        <div>
+            <label class="block mb-1">Correo</label>
+            <input type="email" name="email" class="w-full border rounded px-3 py-2">
+        </div>
+        <div>
+            <label class="block mb-1">Teléfono</label>
+            <input type="text" name="phone" class="w-full border rounded px-3 py-2">
+        </div>
+        <div>
+            <label class="block mb-1">Cargo</label>
+            <input type="text" name="position" class="w-full border rounded px-3 py-2">
+        </div>
+        <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded">Registrarse</button>
+    </form>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,11 @@ Route::put('companies/{company}', [CompanyController::class, 'update'])->name('c
 Route::get('volunteers/create', [VolunteerController::class, 'create'])->name('volunteers.create');
 Route::post('volunteers', [VolunteerController::class, 'store'])->name('volunteers.store');
 
+Route::get('volunteers/signup', [VolunteerController::class, 'signup'])->name('volunteers.signup');
+Route::post('volunteers/signup', [VolunteerController::class, 'signupStore'])->name('volunteers.signup.store');
+Route::get('volunteers/{volunteer}/service', [VolunteerController::class, 'service'])->name('volunteers.service');
+Route::post('volunteers/{volunteer}/service', [VolunteerController::class, 'updateService'])->name('volunteers.service.update');
+
 Route::get('volunteers/{volunteer}/edit', [VolunteerController::class, 'edit'])->name('volunteers.edit');
 Route::put('volunteers/{volunteer}', [VolunteerController::class, 'update'])->name('volunteers.update');
 Route::delete('volunteers/{volunteer}', [VolunteerController::class, 'destroy'])->name('volunteers.destroy');


### PR DESCRIPTION
## Summary
- add service_code column for volunteers
- show and update volunteer service status
- implement mobile signup and service views
- list volunteers in service on dashboard

## Testing
- `php artisan test` *(fails: php not installed)*
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846430e05f08330a22b9d19fe254a6d